### PR TITLE
fix: enable Android Photo Picker and drop READ_MEDIA permission requi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-07-09
+
+### 🔒 Google Play Photo and Video Permissions Policy Compliance
+
+- **Android Photo Picker enabled**: gallery picking now uses the system Photo
+  Picker (`useAndroidPhotoPicker = true`), which runs out-of-process and needs
+  no `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` permission. Devices without
+  Photo Picker support fall back to the legacy intent automatically.
+- **Removed `Permission.photos` gate from the gallery flow**: neither the
+  Android Photo Picker nor iOS PHPicker requires a runtime photo permission.
+  Consumer apps can now drop `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` from
+  their manifests entirely.
+- **`maxImages`/`maxVideos` null = unlimited now works for gallery**: passing
+  null limits no longer fails with "At least one of maxImages or maxVideos
+  must be greater than 0"; the limit is simply omitted (the OS picker may
+  still enforce its own cap, e.g. `MediaStore.getPickImagesMaxLimit()`).
+
 ## [1.0.0] - 2025-12-20
 
 ### 🎉 Initial Release - Unified Media API

--- a/lib/src/core/media_picker.dart
+++ b/lib/src/core/media_picker.dart
@@ -210,7 +210,6 @@ class MediaPicker {
     final galleryDataSource = GalleryDataSourceImpl(imagePicker: ImagePicker());
     const filePickerDataSource = FilePickerDataSourceImpl();
     final compressionDataSource = CompressionDataSourceImpl(compressionOptions);
-    const permissionDataSource = PermissionDataSourceImpl();
 
     // Create mappers
     const imageMapper = ImageMapper();
@@ -227,15 +226,8 @@ class MediaPicker {
       documentMapper: documentMapper,
     );
 
-    const permissionRepository = PermissionRepositoryImpl(
-      permissionDataSource: permissionDataSource,
-    );
-
     // Create use case
-    return GetMediasFromGalleryUsecase(
-      mediaRepository,
-      permissionRepository,
-    );
+    return GetMediasFromGalleryUsecase(mediaRepository);
   }
 
   /// Create GetMediasFromFilesUsecase with all dependencies

--- a/lib/src/data/datasources/gallery/gallery_datasource.dart
+++ b/lib/src/data/datasources/gallery/gallery_datasource.dart
@@ -24,8 +24,9 @@ abstract class GalleryDataSource {
 
   /// Pick mixed media (images and videos) from gallery
   ///
-  /// [maxItems] Maximum total number of media items that can be selected
+  /// [maxItems] Maximum total number of media items that can be selected,
+  /// or null for no limit (the OS picker may still enforce its own cap)
   /// Returns list of [XFile] containing selected media (images and/or videos)
   /// Throws exception if picking fails
-  Future<List<XFile>> pickMixedMedia({required int maxItems});
+  Future<List<XFile>> pickMixedMedia({required int? maxItems});
 }

--- a/lib/src/data/datasources/gallery/gallery_datasource_impl.dart
+++ b/lib/src/data/datasources/gallery/gallery_datasource_impl.dart
@@ -1,4 +1,6 @@
 import 'package:image_picker/image_picker.dart';
+import 'package:image_picker_android/image_picker_android.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../models/image_dto.dart';
@@ -12,7 +14,22 @@ class GalleryDataSourceImpl implements GalleryDataSource {
   final ImagePicker _imagePicker;
 
   GalleryDataSourceImpl({ImagePicker? imagePicker})
-      : _imagePicker = imagePicker ?? ImagePicker();
+      : _imagePicker = imagePicker ?? ImagePicker() {
+    _enableAndroidPhotoPicker();
+  }
+
+  /// Use the Android system Photo Picker instead of ACTION_GET_CONTENT.
+  ///
+  /// The Photo Picker runs out-of-process, so no READ_MEDIA_IMAGES /
+  /// READ_MEDIA_VIDEO permission is needed — required for Google Play's
+  /// Photo and Video Permissions policy. On devices without Photo Picker
+  /// support image_picker falls back to the old intent automatically.
+  static void _enableAndroidPhotoPicker() {
+    final platform = ImagePickerPlatform.instance;
+    if (platform is ImagePickerAndroid) {
+      platform.useAndroidPhotoPicker = true;
+    }
+  }
 
   @override
   Future<List<ImageDto>> pickImages(int maxImages) async {
@@ -43,7 +60,7 @@ class GalleryDataSourceImpl implements GalleryDataSource {
   ///
   /// This is the unified method for picking images and/or videos together
   @override
-  Future<List<XFile>> pickMixedMedia({required int maxItems}) async {
+  Future<List<XFile>> pickMixedMedia({required int? maxItems}) async {
     try {
       // Use pickMultipleMedia to allow both images and videos
       final List<XFile> files = await _imagePicker.pickMultipleMedia(

--- a/lib/src/data/repositories/media_repository_impl.dart
+++ b/lib/src/data/repositories/media_repository_impl.dart
@@ -82,11 +82,17 @@ class MediaRepositoryImpl implements MediaRepository {
         );
       }
 
-      // Calculate total limit
-      final totalLimit = options.maxTotal ??
-          ((options.maxImages ?? 0) + (options.maxVideos ?? 0));
+      // Calculate total limit; null means unlimited (both limits null)
+      final int? totalLimit;
+      if (options.maxTotal != null) {
+        totalLimit = options.maxTotal;
+      } else if (options.maxImages == null && options.maxVideos == null) {
+        totalLimit = null;
+      } else {
+        totalLimit = (options.maxImages ?? 0) + (options.maxVideos ?? 0);
+      }
 
-      if (totalLimit <= 0) {
+      if (totalLimit != null && totalLimit <= 0) {
         return left(
           const MediaFailure.galleryError(
             'At least one of maxImages or maxVideos must be greater than 0.',

--- a/lib/src/domain/usecases/get_medias_from_gallery_usecase.dart
+++ b/lib/src/domain/usecases/get_medias_from_gallery_usecase.dart
@@ -4,22 +4,18 @@ import '../../core/options/media_selection_options.dart';
 import '../entities/media_entity.dart';
 import '../failures/media_failure.dart';
 import '../repositories/media_repository.dart';
-import '../repositories/permission_repository.dart';
 
 /// Use case for getting media (images/videos) from the device gallery
 ///
-/// This use case handles the complete flow of:
-/// 1. Checking photos permission
-/// 2. Requesting permission if not granted
-/// 3. Getting mixed media from gallery
+/// No runtime permission is required: Android uses the system Photo Picker
+/// and iOS uses PHPicker, both of which run out-of-process and grant access
+/// only to the user-selected items. Requesting Permission.photos here would
+/// force apps to declare READ_MEDIA_IMAGES/READ_MEDIA_VIDEO, which Google
+/// Play rejects under the Photo and Video Permissions policy.
 class GetMediasFromGalleryUsecase {
   final MediaRepository _mediaRepository;
-  final PermissionRepository _permissionRepository;
 
-  const GetMediasFromGalleryUsecase(
-    this._mediaRepository,
-    this._permissionRepository,
-  );
+  const GetMediasFromGalleryUsecase(this._mediaRepository);
 
   /// Execute the use case to get media from gallery
   ///
@@ -28,19 +24,6 @@ class GetMediasFromGalleryUsecase {
   Future<Either<MediaFailure, List<MediaEntity>>> execute({
     required MediaSelectionOptions options,
   }) async {
-    // 1. Request photos permission
-    final permissionResult = await _permissionRepository.requestPhotos();
-
-    if (permissionResult.isLeft()) {
-      return left(const MediaFailure.permissionDenied());
-    }
-
-    final hasPermission = permissionResult.getOrElse(() => false);
-    if (!hasPermission) {
-      return left(const MediaFailure.permissionDenied());
-    }
-
-    // 2. Get media from gallery
     return _mediaRepository.getMediasFromGallery(options: options);
   }
 }

--- a/lib/src/domain/usecases/providers.dart
+++ b/lib/src/domain/usecases/providers.dart
@@ -21,7 +21,6 @@ GetMediasFromCameraUsecase getMediasFromCameraUsecase(Ref ref) {
 GetMediasFromGalleryUsecase getMediasFromGalleryUsecase(Ref ref) {
   return GetMediasFromGalleryUsecase(
     ref.watch(mediaRepositoryProvider),
-    ref.watch(permissionRepositoryProvider),
   );
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -506,7 +506,7 @@ packages:
     source: hosted
     version: "1.2.1"
   image_picker_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_android
       sha256: "518a16108529fc18657a3e6dde4a043dc465d16596d20ab2abd49a4cac2e703d"
@@ -546,7 +546,7 @@ packages:
     source: hosted
     version: "0.2.2+1"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_platform_interface
       sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   flutter_image_compress: ^2.3.0
   path_provider: ^2.1.5
   image_picker: ^1.1.2
+  # Android Photo Picker'ı (useAndroidPhotoPicker) etkinleştirmek için gerekli
+  image_picker_android: ^0.8.12
+  image_picker_platform_interface: ^2.10.0
   wolt_modal_sheet: ^0.11.0
   camerawesome:
     git:


### PR DESCRIPTION
…rement

- Enable useAndroidPhotoPicker so gallery picking runs out-of-process (Google Play Photo and Video Permissions policy compliance)
- Remove Permission.photos gate from gallery flow; neither Android Photo Picker nor iOS PHPicker needs a runtime photo permission
- Support null maxImages/maxVideos as unlimited in gallery flow